### PR TITLE
Include locus name and snp position in snp_table.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Master branch build status](https://travis-ci.org/chadlaing/Panseq.svg?branch=master "Master Build Status")](https://travis-ci.org/chadlaing/Panseq)
+# Panseq-LC: fork of Panseq, with output modified to include LocusName in SNP table
 
 ## OVERVIEW
 

--- a/lib/Modules/PanGenome/PanGenome.pm
+++ b/lib/Modules/PanGenome/PanGenome.pm
@@ -722,6 +722,7 @@ sub _printResults{
 					   ,snpChar=>$finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{value}
 					   ,startBp=>$finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp}
 					   ,contigId=>$finalResult->{genomeResults}->{$genome}->{binary}->[0]->{contig_id}
+					   ,$snpStringHash{$snpId}->{'snp_position'} = $finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp}
 					);
 				}
 
@@ -841,7 +842,7 @@ sub _printCoreSnpData{
 sub _printSnpTable{
 	my $self=shift;
 	my $snpStringHash = shift;
-
+	#my $finalResult = shift;
 	my @output;
 	foreach my $id(sort keys %{$snpStringHash}){
 		my $printLine = "\n";
@@ -851,7 +852,10 @@ sub _printSnpTable{
 			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome});
                         my $lociname = $snpStringHash->{$id}->{'loci'};
                         my $refgenome = (split /|/, $lociname)[1];
-                        $startbp = 150 if $genome==$refgenome; 
+                        $startbp = $snpStringHash->{$id}->{'snp_position'} if $snpStringHash->{$id}->{$genome}==$refgenome;
+                        #print "$snpStringHash->{$id}"
+                        #print $params->{$id}->{$startBp}
+                        #print"$finalResult->{$genome}->{$id}->{$start_bp}";
 		}
                 my $snploci = $printLine . "\t" . $snpStringHash->{$id}->{'loci'} . "\t" . $startbp;
 		push @output, $snploci; #, $printLine;

--- a/lib/Modules/PanGenome/PanGenome.pm
+++ b/lib/Modules/PanGenome/PanGenome.pm
@@ -722,18 +722,10 @@ sub _printResults{
 					   ,snpChar=>$finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{value}
 					   ,startBp=>$finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp}
 					   ,contigId=>$finalResult->{genomeResults}->{$genome}->{binary}->[0]->{contig_id}
-					   #,$lname= $finalResult->{locusInformation}->{name};
-					   #,$refgenome = (split /|/, $lname)[1];
-					   #,$snpStringHash{$snpId}->{'snp_position'} = $finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp} #if $genome==$refgenome;
 					);
 					my $lname = "" . $snpStringHash{$snpId}->{'loci'};
-					#print"$lname\n";
-					#my $delim = '|';
 					my @refgenome = (split(/[|]/, $lname));
 					my $refgenome_ = $refgenome[1];
-					#print"@refgenome\n";
-					#print "$refgenome_";
-					#print"\n";
 					$snpStringHash{$snpId}->{'snp_position'} = $finalResult->{genomeResults}->{$refgenome_}->{snp}->{$snpId}->{start_bp}; #if $refgenome==$genome;
 				}
 
@@ -863,13 +855,10 @@ sub _printSnpTable{
 			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome});
                         my $lociname = $snpStringHash->{$id}->{'loci'};
                         my $refgenome = (split /|/, $lociname)[1];
-                        $startbp = $snpStringHash->{$id}->{'snp_position'}; #if $snpStringHash->{$id}->{$genome}==$refgenome;
-                        #print "$snpStringHash->{$id}"
-                        #print $params->{$id}->{$startBp}
-                        #print"$finalResult->{$genome}->{$id}->{$start_bp}";
+                        $startbp = $snpStringHash->{$id}->{'snp_position'};
 		}
                 my $snploci = $printLine . "\t" . $snpStringHash->{$id}->{'loci'} . "\t" . $startbp;
-		push @output, $snploci; #, $printLine;
+		push @output, $snploci;
 	}
 	$self->_printFH->{snpTableFH}->print(@output);
 }

--- a/lib/Modules/PanGenome/PanGenome.pm
+++ b/lib/Modules/PanGenome/PanGenome.pm
@@ -845,10 +845,15 @@ sub _printSnpTable{
 	my @output;
 	foreach my $id(sort keys %{$snpStringHash}){
 		my $printLine = "\n";
+                my $startbp = ''; #get ref start ID
+                
 		foreach my $genome(1..scalar(@{$self->settings->orderedGenomeNames})){
-			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome}) #. $snpStringHash->{$id}->{$genome})
+			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome});
+                        my $lociname = $snpStringHash->{$id}->{'loci'};
+                        my $refgenome = (split /|/, $lociname)[1];
+                        $startbp = 150 if $genome==$refgenome; 
 		}
-                my $snploci = $printLine . "\t" . $snpStringHash->{$id}->{'loci'};
+                my $snploci = $printLine . "\t" . $snpStringHash->{$id}->{'loci'} . "\t" . $startbp;
 		push @output, $snploci; #, $printLine;
 	}
 	$self->_printFH->{snpTableFH}->print(@output);

--- a/lib/Modules/PanGenome/PanGenome.pm
+++ b/lib/Modules/PanGenome/PanGenome.pm
@@ -722,8 +722,19 @@ sub _printResults{
 					   ,snpChar=>$finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{value}
 					   ,startBp=>$finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp}
 					   ,contigId=>$finalResult->{genomeResults}->{$genome}->{binary}->[0]->{contig_id}
-					   ,$snpStringHash{$snpId}->{'snp_position'} = $finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp}
+					   #,$lname= $finalResult->{locusInformation}->{name};
+					   #,$refgenome = (split /|/, $lname)[1];
+					   #,$snpStringHash{$snpId}->{'snp_position'} = $finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{start_bp} #if $genome==$refgenome;
 					);
+					my $lname = "" . $snpStringHash{$snpId}->{'loci'};
+					#print"$lname\n";
+					#my $delim = '|';
+					my @refgenome = (split(/[|]/, $lname));
+					my $refgenome_ = $refgenome[1];
+					#print"@refgenome\n";
+					#print "$refgenome_";
+					#print"\n";
+					$snpStringHash{$snpId}->{'snp_position'} = $finalResult->{genomeResults}->{$refgenome_}->{snp}->{$snpId}->{start_bp}; #if $refgenome==$genome;
 				}
 
 				#if there are SNPs in a region, add dashes to the snp string
@@ -852,7 +863,7 @@ sub _printSnpTable{
 			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome});
                         my $lociname = $snpStringHash->{$id}->{'loci'};
                         my $refgenome = (split /|/, $lociname)[1];
-                        $startbp = $snpStringHash->{$id}->{'snp_position'} if $snpStringHash->{$id}->{$genome}==$refgenome;
+                        $startbp = $snpStringHash->{$id}->{'snp_position'}; #if $snpStringHash->{$id}->{$genome}==$refgenome;
                         #print "$snpStringHash->{$id}"
                         #print $params->{$id}->{$startBp}
                         #print"$finalResult->{$genome}->{$id}->{$start_bp}";

--- a/lib/Modules/PanGenome/PanGenome.pm
+++ b/lib/Modules/PanGenome/PanGenome.pm
@@ -714,7 +714,7 @@ sub _printResults{
 
 				foreach my $snpId(sort keys %{$finalResult->{genomeResults}->{$genome}->{snp}}){
 					$snpStringHash{$snpId}->{$genomeCounter} = $finalResult->{genomeResults}->{$genome}->{snp}->{$snpId}->{value};
-				
+                                        $snpStringHash{$snpId}->{'loci'} = $finalResult->{locusInformation}->{name};				
 					$self->_printCoreSnpData(
 						snpId=>$snpId
 					   ,locusName=>$finalResult->{locusInformation}->{name}
@@ -846,9 +846,10 @@ sub _printSnpTable{
 	foreach my $id(sort keys %{$snpStringHash}){
 		my $printLine = "\n";
 		foreach my $genome(1..scalar(@{$self->settings->orderedGenomeNames})){
-			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome})
+			$printLine .= ("\t" . $snpStringHash->{$id}->{$genome}) #. $snpStringHash->{$id}->{$genome})
 		}
-		push @output, $printLine;
+                my $snploci = $printLine . "\t" . $snpStringHash->{$id}->{'loci'};
+		push @output, $snploci; #, $printLine;
 	}
 	$self->_printFH->{snpTableFH}->print(@output);
 }
@@ -1157,6 +1158,7 @@ sub _getCoreResult {
 	 #this returns undef if there are no SNPs
 	 return $snpDataArrayRef;	
 }
+
 
 1;
 

--- a/t/genomes.batch
+++ b/t/genomes.batch
@@ -1,0 +1,10 @@
+queryDirectory	t/data/genomes/
+percentIdentityCutoff	90
+coreGenomeThreshold	3
+minimumNovelRegionSize	1000
+fragmentationSize	1000
+overwrite	1
+nameOrId	name
+baseDirectory	t/genomes/
+numberOfCores	1
+runMode	pan

--- a/t/plasmids.batch
+++ b/t/plasmids.batch
@@ -1,0 +1,14 @@
+percentIdentityCutoff	90
+queryDirectory	t/data/plasmids/
+coreGenomeThreshold	2
+cdhitDirectory	/mnt/gvl/apps/linuxbrew/bin/
+minimumNovelRegionSize	500
+fragmentationSize	500
+allelesToKeep	2
+nameOrId	name
+overwrite	1
+runMode	pan
+storeAlleles	1
+numberOfCores	1
+cdhit	1
+baseDirectory	t/plasmids/

--- a/t/query.batch
+++ b/t/query.batch
@@ -1,0 +1,12 @@
+storeAlleles	1
+runMode	pan
+queryFile	t/data/testfragments.fasta
+baseDirectory	t/query/
+numberOfCores	1
+overwrite	1
+nameOrId	name
+minimumNovelRegionSize	1
+fragmentationSize	0
+coreGenomeThreshold	2
+percentIdentityCutoff	90
+queryDirectory	t/data/genomes/


### PR DESCRIPTION
Hi Chad, 

I've coded Panseq so to output locus name and snp position (per the reference) to the end of each row of the snp_table.txt output. With many genomes core_snps.txt can become massive whereas snp_table.txt remains a manageable size! 

I don't code in perl so apologies for any untidiness in this solution! 

Best regards, 

Matt 